### PR TITLE
 Add Hardware ID for Space Mouse BT Editions

### DIFF
--- a/RawMouse/config.json
+++ b/RawMouse/config.json
@@ -22,6 +22,8 @@
     [ "0x256f", "0xc632", "spacemouse", "3Dconnexion Space Mouse Pro Wireless" ],
     [ "0x256f", "0xc633", "spacemouse", "3Dconnexion Space Mouse Enterprise" ],
     [ "0x256f", "0xc635", "spacemouse", "3Dconnexion Space Mouse Compact" ],
+    [ "0x256f", "0xc638", "spacemouse", "3Dconnexion Space Mouse Pro Wireless BT" ],
+    [ "0x256f", "0xc63a", "spacemouse", "3Dconnexion Space Mouse Wireless BT" ],
     [ "0x256f", "0xc652", "spacemouse", "3Dconnexion Space Mouse Universal Receiver",
       { "platform": "Linux" } ],
     [ "0x256f", "0xc652", "spacemouse", "3Dconnexion Space Mouse Universal Receiver",


### PR DESCRIPTION
Thanks for maintain the plugin, it works great.

Add hardware ID for new [SpaceMouse Wireless Bluetooth Edition](https://3dconnexion.com/us/product/spacemouse-wireless/).
It shows up with the same hardware ID in wired and bluetooth modes. Name taken from [here](https://github.com/openscad/openscad/blob/dbd7d4f3d93356fedc0cfac1989e2a1e85335de8/src/gui/input/HidApiInputDriver.cc#L75C1-L75C142).

There is also a bluetooth version for the Pro. I found its hardware ID [here](https://github.com/nytamin/spacemouse/blob/6dbc8fc16a365205d80431c31280438c33cc4563/packages/core/src/products.ts#L57-L61).
